### PR TITLE
Added instructions for downloading pre-reqs on Digital Research Alliance of Canada (DRAC) clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install ml_collections dm_tree
 ```
 
 Also, in your `LigandMPNN/openfold/np` folder, change all file instances of `np.int` (if using a deprecated version) to `np.int32` 
-(or another class like `int` or `np.int64` depending on desired precision). 
+(or another type like `int` or `np.int64` depending on desired precision). 
 
 ### Main differences compared with [ProteinMPNN](https://github.com/dauparas/ProteinMPNN) code
 - Input PDBs are parsed using [Prody](https://pypi.org/project/ProDy/) preserving protein residue indices, chain letters, and insertion codes. If there are missing residues in the input structure the output fasta file won't have added `X` to fill the gaps. The script outputs .fasta and .pdb files. It's recommended to use .pdb files since they will hold information about chain letters and residue indices.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ pip3 install torch
 pip install prody
 ```
 
+#### Digital Research Alliance of Canada (DRAC) clusters
+For some DRAC clusters (e.g. Graham), the above is not enough to run LigandMPNN.
+
+The following pip installs are needed in addition (do this in your `virtualenv`):
+```
+pip install ml_collections dm_tree
+```
+
+Also, in your `LigandMPNN/openfold/np` folder, change all file instances of `np.int` (if using a deprecated version) to `np.int32`. 
+
 ### Main differences compared with [ProteinMPNN](https://github.com/dauparas/ProteinMPNN) code
 - Input PDBs are parsed using [Prody](https://pypi.org/project/ProDy/) preserving protein residue indices, chain letters, and insertion codes. If there are missing residues in the input structure the output fasta file won't have added `X` to fill the gaps. The script outputs .fasta and .pdb files. It's recommended to use .pdb files since they will hold information about chain letters and residue indices.
 - Adding bias, fixing residues, and selecting residues to be redesigned now can be done using residue indices directly, e.g. A23 (means chain A residue with index 23), B42D (chain B, residue 42, insertion code D).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The following pip installs are needed in addition (do this in your `virtualenv`)
 pip install ml_collections dm_tree
 ```
 
-Also, in your `LigandMPNN/openfold/np` folder, change all file instances of `np.int` (if using a deprecated version) to `np.int32`. 
+Also, in your `LigandMPNN/openfold/np` folder, change all file instances of `np.int` (if using a deprecated version) to `np.int32` 
+(or another class like `int` or `np.int64` depending on desired precision). 
 
 ### Main differences compared with [ProteinMPNN](https://github.com/dauparas/ProteinMPNN) code
 - Input PDBs are parsed using [Prody](https://pypi.org/project/ProDy/) preserving protein residue indices, chain letters, and insertion codes. If there are missing residues in the input structure the output fasta file won't have added `X` to fill the gaps. The script outputs .fasta and .pdb files. It's recommended to use .pdb files since they will hold information about chain letters and residue indices.


### PR DESCRIPTION
Some of the files within LigandMPNN's repo (like `LigandMPNN/openfold/np/residue_constants.py` and `./openfold/data/data_modules.py`) contain certain modules (e.g. `tree` and `ml_collections` respectively) that were not downloaded into the virtualenv if following the currently available instructions, and would cause import errors if LigandMPNN was attempted to run on DRAC clusters. 

This new commit would fix these issues (mainly by running `pip install ml_collections dm_tree` in the respective virtualenv).