### PR TITLE
Enable easy running outside of installation directory.

### DIFF
--- a/run.py
+++ b/run.py
@@ -64,7 +64,13 @@ def main(args) -> None:
     else:
         print("Choose one of the available models")
         sys.exit()
+    # If the checkpoint isn't in the local directory, try to load it relative to the script directory.
+    if not os.path.exists(checkpoint_path):
+        alt_path = os.path.join( os.path.dirname(os.path.abspath(__file__)), checkpoint_path )
+        if os.path.exists(alt_path):
+            checkpoint_path = alt_path
     checkpoint = torch.load(checkpoint_path, map_location=device)
+
     if args.model_type == "ligand_mpnn":
         atom_context_num = checkpoint["atom_context_num"]
         ligand_mpnn_use_side_chain_context = args.ligand_mpnn_use_side_chain_context


### PR DESCRIPTION
Currently the default checkpoint path specifications assumes that things are being run from within the installation directory. This make it hard to run the script from a different working directory.

These edits should keep the current behavior if the checkpoint specification is indeed a local/relative directory, but will fallback to the central install (script location) directory if the file is not present, allowing for running outside of the installation directory.