### PR TITLE
Added conda activate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ bash get_model_params.sh "./model_params"
 
 #setup your conda/or other environment
 #conda create -n ligandmpnn_env python=3.11
+#conda activate ligandmpnn_env
 #pip3 install -r requirements.txt
 
 python run.py \
@@ -26,6 +27,7 @@ To run the model you will need to have Python>=3.0, PyTorch, Numpy installed, an
 For example to make a new conda environment for LigandMPNN run:
 ```
 conda create -n ligandmpnn_env python=3.11
+conda activate ligandmpnn_env
 pip3 install -r requirements.txt
 ```
 


### PR DESCRIPTION
I noticed that the "conda activate" command was missing from the README file.

This is slightly misleading and could lead to users creating the conda environment, but then using the system `pip3` to install packages locally instead of within the environment.